### PR TITLE
Fix/001 scanner does not works properly on windows

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -17,7 +17,6 @@ await build({
   target: 'esnext',
   platform: 'node',
   bundle: true,
-  keepNames: true,
   external: [
     'lithia',
     ...subpaths.map((subpath) => `lithia/${subpath}`),
@@ -69,7 +68,7 @@ await globby('.', {
           let relativePath = relative(
             dirname(fullPath),
             join(process.cwd(), 'dist', resolvedPath, 'index.js'),
-          );
+          ).replace(/\\/g, '/');
 
           if (relativePath[0] !== '.') {
             relativePath = `./${relativePath}`;

--- a/example/src/routes/hello.ts
+++ b/example/src/routes/hello.ts
@@ -1,0 +1,7 @@
+import { LithiaRequest, LithiaResponse } from '../../../dist/types';
+
+export default async function handler(req: LithiaRequest, res: LithiaResponse) {
+  res.json({
+    message: 'Hello World!!!!!!!!!!!',
+  });
+}

--- a/example/src/routes/users/[id].get.ts
+++ b/example/src/routes/users/[id].get.ts
@@ -1,0 +1,5 @@
+import { LithiaRequest, LithiaResponse } from '../../../../dist/types';
+
+export default async function handler(req: LithiaRequest, res: LithiaResponse) {
+  res.json(req.params);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lithia",
-  "version": "2.0.0",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lithia",
-      "version": "2.0.0",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "@esbuild-plugins/tsconfig-paths": "^0.1.2",

--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -29,7 +29,8 @@ export async function scanServerRoutes(lithia: Lithia): Promise<Route[]> {
       .replace(/\(([^(/\\]+)\)[/\\]/g, '')
       .replace(/\[\.{3}]/g, '**')
       .replace(/\[\.{3}(\w+)]/g, '**:$1')
-      .replace(/\[([^/\]]+)]/g, ':$1');
+      .replace(/\[([^/\]]+)]/g, ':$1')
+      .replace(/\\/g, '/');
 
     path = withLeadingSlash(
       withoutTrailingSlash(withBase(path, lithia.options.router.globalPrefix)),

--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -6,10 +6,8 @@ import {
   MatchedMethodSuffix,
   Route,
 } from 'lithia/types';
-import { join, relative } from 'node:path';
+import nodePath from 'node:path';
 import { withBase, withLeadingSlash, withoutTrailingSlash } from 'ufo';
-
-const GLOB_SCAN_PATTERN = '**/*.ts';
 
 const suffixRegex =
   /(\.(?<method>connect|delete|get|head|options|patch|post|put|trace))?(\.(?<env>dev|prod))?$/;
@@ -17,7 +15,11 @@ const suffixRegex =
 export async function scanServerRoutes(lithia: Lithia): Promise<Route[]> {
   const files = await scanDir({
     dir: process.cwd(),
-    name: join(lithia.options.srcDir, lithia.options.routesDir),
+    name: nodePath.resolve(
+      process.cwd(),
+      lithia.options.srcDir,
+      lithia.options.routesDir,
+    ),
     ignore: ['**/*.{spec,test}.ts'],
   });
 
@@ -70,7 +72,10 @@ type ScanDirOptions = {
 };
 
 async function scanDir(options: ScanDirOptions): Promise<FileInfo[]> {
-  const fileNames = await globby(join(options.name, GLOB_SCAN_PATTERN), {
+  const normalizedName = options.name.replace(/\\/g, '/');
+  const pattern = `${normalizedName}/**/*.ts`;
+
+  const fileNames = await globby(pattern, {
     cwd: options.dir,
     dot: true,
     ignore: options.ignore,
@@ -79,9 +84,11 @@ async function scanDir(options: ScanDirOptions): Promise<FileInfo[]> {
 
   return fileNames
     .map((fullPath) => {
+      const path = nodePath.relative(normalizedName, fullPath);
+
       return {
         fullPath,
-        path: relative(join(options.dir, options.name), fullPath),
+        path,
       };
     })
     .sort((a, b) => a.path.localeCompare(b.path));


### PR DESCRIPTION
This pull request includes several changes to improve the build process and route handling in the project. The most important changes include modifications to the `build.ts` file for path normalization, updates to route handler files for consistency, and improvements to the route scanning functionality.

### Build process improvements:

* [`build.ts`](diffhunk://#diff-f688787507463e6c56fb47f33fddc00fa9f3494eac70ff156e7638e96c80905cL20): Removed the `keepNames` option from the build configuration and normalized paths to use forward slashes. [[1]](diffhunk://#diff-f688787507463e6c56fb47f33fddc00fa9f3494eac70ff156e7638e96c80905cL20) [[2]](diffhunk://#diff-f688787507463e6c56fb47f33fddc00fa9f3494eac70ff156e7638e96c80905cL72-R71)

### Route handler updates:

* [`example/src/routes/hello.ts`](diffhunk://#diff-4ed5ca22ac54c362454f87364f90f47855eac9752a2ab2f6ac788161eb5f7903R1-R7): Added a new route handler for the `/hello` endpoint, importing `LithiaRequest` and `LithiaResponse` types.
* `example/src/routes/users/[id].get.ts`: Added a new route handler for the `/users/[id]` endpoint, importing `LithiaRequest` and `LithiaResponse` types. ([example/src/routes/users/[id].get.tsR1-R5](diffhunk://#diff-800710d2bc7bec9e54d83dc1e0d6761d0a627633917b1974d0ab76fec822f1cfR1-R5))

### Route scanning improvements:

* [`src/core/scan.ts`](diffhunk://#diff-e5c55387b5c2fb61ff1e6af54cfd3a1d4871dadbb77dec8f9f65495983edc5e6L9-R22): Replaced `join` and `relative` imports with `nodePath` and normalized paths to use forward slashes. [[1]](diffhunk://#diff-e5c55387b5c2fb61ff1e6af54cfd3a1d4871dadbb77dec8f9f65495983edc5e6L9-R22) [[2]](diffhunk://#diff-e5c55387b5c2fb61ff1e6af54cfd3a1d4871dadbb77dec8f9f65495983edc5e6L30-R33) [[3]](diffhunk://#diff-e5c55387b5c2fb61ff1e6af54cfd3a1d4871dadbb77dec8f9f65495983edc5e6L73-R79) [[4]](diffhunk://#diff-e5c55387b5c2fb61ff1e6af54cfd3a1d4871dadbb77dec8f9f65495983edc5e6R88-R92)